### PR TITLE
Dispatch over content-type to allow types such as "text/html; charset=utf-8"

### DIFF
--- a/src/clojure/clojurewerkz/mailer/core.clj
+++ b/src/clojure/clojurewerkz/mailer/core.clj
@@ -98,11 +98,24 @@
   [content-type]
   (str (namespace content-type) "/" (name content-type)))
 
+(defprotocol ContentType
+  (get-content-type [value]))
+
+(extend-protocol ContentType
+  clojure.lang.Keyword
+    (get-content-type
+      [k]
+      (mime-type-str k))
+  java.lang.String
+    (get-content-type
+      [s]
+      s))
+
 (defn build-email
   "Builds up a mail message (returned as an immutable map). Body is rendered from a given template."
   ([m ^String template data content-type]
      (merge *message-defaults* m {:body [{:content (render template data)
-                                          :type (mime-type-str content-type)}]})))
+                                          :type (get-content-type content-type)}]})))
 
 
 (defn deliver-email

--- a/test/clojurewerkz/mailer/core_test.clj
+++ b/test/clojurewerkz/mailer/core_test.clj
@@ -56,6 +56,17 @@
           (is (= type expected-type)))))))
 
 
+
+(deftest test-content-type-keyword
+  (let [email (build-email {} "templates/hello.mustache" {} :text/html)
+        type (:type (first (:body email)))]
+      (is (= type "text/html"))))
+
+(deftest test-content-type-string
+  (let [email (build-email {} "templates/hello.mustache" {} "text/html")
+        type (:type (first (:body email)))]
+    (is (= type "text/html"))))
+
 ;;
 ;; Test Delivery
 ;;


### PR DESCRIPTION
Current way of setting type via keyword is not flexible enough, in my case I needed `text/html; charset=utf-8` so such modification came handy. (Unless of course I missed some other way of setting it;) )
