### PR TITLE
[MF] allow merging of :body maps to enable attachments

### DIFF
--- a/src/clojure/clojurewerkz/mailer/core.clj
+++ b/src/clojure/clojurewerkz/mailer/core.clj
@@ -111,11 +111,21 @@
       [s]
       s))
 
+(defn deep-merge-into
+  "Recursively merge maps applying into when there's a non-map. based on conjure.contrib/map_utils deep-merge-with"
+  [& maps]
+  (apply
+    (fn m [& maps]
+      (if (every? map? maps)
+        (apply merge-with m maps)
+        (apply into maps)))
+    maps))
+
 (defn build-email
   "Builds up a mail message (returned as an immutable map). Body is rendered from a given template."
   ([m ^String template data content-type]
-     (merge *message-defaults* m {:body [{:content (render template data)
-                                          :type (get-content-type content-type)}]})))
+     (deep-merge-into *message-defaults* m {:body [{:content (render template data)
+                                                    :type (get-content-type content-type)}]})))
 
 
 (defn deliver-email

--- a/test/clojurewerkz/mailer/core_test.clj
+++ b/test/clojurewerkz/mailer/core_test.clj
@@ -46,7 +46,7 @@
         (let [email (build-email {:from    "fee@bar.dom"
                                   :to      "Foo Bar <foo@bar.dom>"
                                   :subject "Hello"}
-                                 "templates/hello.mustache" {:name "Joe"} 
+                                 "templates/hello.mustache" {:name "Joe"}
                                  :text/plain)
               content (:content (first (:body email)))
               type (:type (first (:body email)))]
@@ -104,3 +104,18 @@
 ;;
 
 ;; TBD
+
+;;
+;; Merging
+;;
+
+(deftest test-merged-maps
+  (is (= {:body [:alternative
+                 {:type "text/plain" :content "test content"}
+                 {:type "text/html" :content "<p>content</p>"}]
+          :subject "subj"
+          :to "person@anywhere.com"}
+         (deep-merge-into {:body [:alternative {:content "test content" :type "text/plain"}]
+                           :subject "subj"
+                           :to "person@anywhere.com"}
+                          {:body [{:content "<p>content</p>" :type "text/html"}]}))))


### PR DESCRIPTION
I couldn't see how mailer could create attachments as it uses merge, which would overwrite any :body entries in message-defaults.

I've changed it to now use a deep-merge of the maps, which allows message-defaults to contain other body elements, which is how postal treats attachments.

It should now create maps like in postal's example at https://github.com/drewr/postal#attachments

Warning, i've only written the code and test to do the merging, not actually tried to send emails yet with this code. Just wanted to generate some feedback and see if this was an acceptable change or not?
