### PR TITLE
Alternative email bodies

### DIFF
--- a/src/clojure/clojurewerkz/mailer/core.clj
+++ b/src/clojure/clojurewerkz/mailer/core.clj
@@ -134,7 +134,7 @@
                       (partition-all 3 (concat [template data content-type] more-data)))]
     (deep-merge-into *message-defaults* m
                      {:body (if (empty? more-data)
-                              (first contents)
+                              contents
                               (cons :alternative contents))})))
 
 


### PR DESCRIPTION
Allow multiple templates/data/content-type triples in `build-email` and `deliver-email` to enable alternative email bodies (most commonly HTML + plain text).
