### PR TITLE
Wrap template rendering exception

### DIFF
--- a/src/clojure/clojurewerkz/mailer/core.clj
+++ b/src/clojure/clojurewerkz/mailer/core.clj
@@ -55,7 +55,6 @@
   `(when (nil? ~v)
      (throw (IllegalArgumentException. ~m))))
 
-
 ;;
 ;; API
 ;;
@@ -92,7 +91,11 @@
      (render template {}))
   ([^String template data]
      (check-not-nil! template "Template resource name cannot be nil!")
-     (clostache/render-resource template data)))
+     (try
+       (clostache/render-resource template data)
+       (catch Exception e
+         (throw (RuntimeException. (str "Failed rendering email with template: '" template "', template might not exist.")
+                                   e))))))
 
 (defn- mime-type-str
   [content-type]


### PR DESCRIPTION
Wrap possible exception during template rendering. This is intend to add more descriptive message for issue #4. 
